### PR TITLE
fix: simplify Dockerfile Java 21 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,5 @@
 # Build stage
-FROM openjdk:21-jdk-slim AS build
-
-# Install specific Maven version (e.g., 3.x.x)
-ARG MAVEN_VERSION=3.9.11
-RUN apt-get update && apt-get install -y curl \
-    && curl -kfsSL https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -o maven.tar.gz \
-    && tar -xzf maven.tar.gz -C /opt \
-    && ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/bin/mvn \
-    && rm -rf maven.tar.gz \
-    && mkdir /flyway
+FROM maven:3.9.11-eclipse-temurin-21 AS build
 
 WORKDIR /build
 
@@ -24,15 +15,11 @@ WORKDIR /build/application
 RUN mvn clean package -DskipTests
 
 # Run stage
-FROM openjdk:21-jdk-slim AS run
+FROM maven:3.9.11-eclipse-temurin-21 AS run
 WORKDIR /app
 
 # Copy the built application JAR from the build stage
 COPY --from=build /build/application/target/*.jar application.jar
-
-# Copy the Maven installation from the build stage
-COPY --from=build /opt/apache-maven* /opt/apache-maven
-RUN ln -s /opt/apache-maven/bin/mvn /usr/bin/mvn
 
 # Copy Migration files to flyway folder
 COPY resources/flyway /flyway


### PR DESCRIPTION
## Summary
- replace the broken/manual OpenJDK + Maven setup with the official Maven Temurin 21 image
- keep the build and run stages on a consistent Java 21 toolchain
- remove the fragile runtime Maven copy step

## Validation
- `make run-all-tests`