### PR TITLE
feat: publish user completed payload to RabbitMQ

### DIFF
--- a/.docker-compose-local/application.yaml
+++ b/.docker-compose-local/application.yaml
@@ -21,6 +21,10 @@ services:
       dockerfile: Dockerfile
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+      SPRING_RABBITMQ_HOST: rabbitmq
+      SPRING_RABBITMQ_PORT: 5672
+      SPRING_RABBITMQ_USERNAME: user
+      SPRING_RABBITMQ_PASSWORD: password
       DATABASE_URL: jdbc:mysql://database/sampledb
       DATABASE_USER: root
       DATABASE_PASSWORD: rpassword

--- a/.docker-compose-local/infrastructure.yaml
+++ b/.docker-compose-local/infrastructure.yaml
@@ -53,6 +53,17 @@ services:
     networks:
       - kafka-net
 
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: user
+      RABBITMQ_DEFAULT_PASS: password
+    networks:
+      - kafka-net
+
 networks:
   database-net:
     driver: bridge

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ See the stack: [docker-compose-infrastructure.yaml](.docker-compose-local/infras
 
 - **MySQL**: Relational database system, accessible at `localhost:3306`.
 - **Kafka**: Event streaming platform, available at `localhost:9092`.
+- **RabbitMQ**: Integration messaging broker, available at `localhost:5672` with the management UI at [http://localhost:15672](http://localhost:15672).
 
 These services are orchestrated using Docker Compose to ensure seamless setup and operation in a local development environment.
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -187,6 +187,7 @@ Veja a stack: [docker-compose-infrastructure.yaml](.docker-compose-local/infrast
 
 - **MySQL**: Relational database system, accessible at `localhost:3306`.
 - **Kafka**: Event streaming platform, available at `localhost:9092`.
+- **RabbitMQ**: Broker de mensageria para integrações, disponível em `localhost:5672`, com a interface de gerenciamento em [http://localhost:15672](http://localhost:15672).
 
 Esses serviços são orquestrados usando o Docker Compose para garantir configuração e operação perfeitas em um ambiente de desenvolvimento local.
 

--- a/acceptance-test/src/test/java/br/com/helpdev/acceptance/UserEnrichProcessIT.java
+++ b/acceptance-test/src/test/java/br/com/helpdev/acceptance/UserEnrichProcessIT.java
@@ -6,6 +6,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import static io.restassured.RestAssured.given;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -48,9 +51,21 @@ class UserEnrichProcessIT extends DefaultContainerStarter {
                .statusCode(200)
                .body("name", equalTo("John Doe"))
                .body("email", equalTo("d9D0r@example.com"))
-               .body("birth_date", equalTo("1990-01-01"))
-               .body("address", notNullValue());
+                .body("birth_date", equalTo("1990-01-01"))
+                .body("address", notNullValue());
       });
+
+      waitAtMost(10, SECONDS).untilAsserted(() -> assertEquals(1, getRabbitMqQueueMessageCount(USER_COMPLETED_QUEUE)));
+
+      final var userUuid = locationValue.substring(locationValue.lastIndexOf('/') + 1);
+      final var rabbitMqPayload = getSingleRabbitMqQueueMessage(USER_COMPLETED_QUEUE);
+
+      assertNotNull(rabbitMqPayload);
+      assertTrue(rabbitMqPayload.contains("\"uuid\":\"" + userUuid + "\""));
+      assertTrue(rabbitMqPayload.contains("\"name\":\"John Doe\""));
+      assertTrue(rabbitMqPayload.contains("\"email\":\"d9D0r@example.com\""));
+      assertTrue(rabbitMqPayload.contains("\"city\":\"East Nadia\""));
+      assertTrue(rabbitMqPayload.contains("\"country\":\"Reunion\""));
    }
 
    @Test
@@ -79,6 +94,8 @@ class UserEnrichProcessIT extends DefaultContainerStarter {
             .body("email", equalTo("d9D0r@example.com"))
             .body("birth_date", equalTo("1990-01-01"))
             .body("address", nullValue());
+
+      assertEquals(0, getRabbitMqQueueMessageCount(USER_COMPLETED_QUEUE));
    }
 
 }

--- a/acceptance-test/src/test/java/br/com/helpdev/acceptance/containers/DefaultContainerStarter.java
+++ b/acceptance-test/src/test/java/br/com/helpdev/acceptance/containers/DefaultContainerStarter.java
@@ -1,8 +1,12 @@
 package br.com.helpdev.acceptance.containers;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.restassured.RestAssured.given;
 
 import io.restassured.RestAssured;
+
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.slf4j.LoggerFactory;
@@ -27,11 +31,25 @@ public abstract class DefaultContainerStarter {
 
    private static final KafkaContainer KAFKA_CONTAINER;
 
+   private static final GenericContainer<?> RABBITMQ_CONTAINER;
+
    private static final Network NETWORK = Network.newNetwork();
 
    protected static final WireMockServer MOCK_SERVER;
 
+   protected static final String USER_COMPLETED_QUEUE = "user-completed.integration.queue";
+
    public static final String DOCKER_IMAGE_APP = "application:acceptance-test";
+
+   private static final String RABBITMQ_USERNAME = "user";
+
+   private static final String RABBITMQ_PASSWORD = "password";
+
+   private static final int RABBITMQ_AMQP_PORT = 5672;
+
+   private static final int RABBITMQ_MANAGEMENT_PORT = 15672;
+
+   private static final String RABBITMQ_DEFAULT_VHOST = "%2F";
 
    /* Containers are initialized in static block to create only once in test execution */
    static {
@@ -42,13 +60,16 @@ public abstract class DefaultContainerStarter {
       KAFKA_CONTAINER = buildKafkaContainer();
       KAFKA_CONTAINER.start();
 
+      RABBITMQ_CONTAINER = buildRabbitMqContainer();
+      RABBITMQ_CONTAINER.start();
+
       MYSQL_CONTAINER = buildMySqlContainer();
       MYSQL_CONTAINER.start();
 
       FLYWAY = buildFlywayContainerFromApp(MYSQL_CONTAINER);
       FLYWAY.start();
 
-      APP = buildAppContainer(MYSQL_CONTAINER, FLYWAY, KAFKA_CONTAINER);
+      APP = buildAppContainer(MYSQL_CONTAINER, FLYWAY, KAFKA_CONTAINER, RABBITMQ_CONTAINER);
       APP.start();
 
       initRestAssured();
@@ -68,7 +89,18 @@ public abstract class DefaultContainerStarter {
             .withEnv("DATABASE_USER", MYSQL_CONTAINER.getUsername())
             .withEnv("DATABASE_PASSWORD", MYSQL_CONTAINER.getPassword())
             .waitingFor(Wait.forLogMessage("(?s).*No migration necessary(?s).*|(?s).*Successfully applied(?s).*", 1))
-            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("FLYWAY")));
+             .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("FLYWAY")));
+   }
+
+   private static GenericContainer<?> buildRabbitMqContainer() {
+      return new GenericContainer<>("rabbitmq:3.13-management")
+            .withExposedPorts(RABBITMQ_AMQP_PORT, RABBITMQ_MANAGEMENT_PORT)
+            .withEnv("RABBITMQ_DEFAULT_USER", RABBITMQ_USERNAME)
+            .withEnv("RABBITMQ_DEFAULT_PASS", RABBITMQ_PASSWORD)
+            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("RABBITMQ_CONTAINER")))
+            .withNetworkAliases("rabbitmq")
+            .withNetwork(NETWORK)
+            .waitingFor(Wait.forLogMessage(".*Server startup complete.*", 1));
    }
 
    private static KafkaContainer buildKafkaContainer() {
@@ -87,12 +119,16 @@ public abstract class DefaultContainerStarter {
             .withEnv("DATABASE_USER", MYSQL_CONTAINER.getUsername())
             .withEnv("DATABASE_PASSWORD", MYSQL_CONTAINER.getPassword())
             .withEnv("OTEL_EXPORTER_OTLP_METRICS_ENABLED", "false")
-            .withEnv("OTEL_EXPORTER_OTLP_TRACES_ENABLED", "false")
-            .withEnv("DATABASE_URL", "jdbc:mysql://mysqldb:" + MySQLContainer.MYSQL_PORT + "/test?autoReconnect=true&useSSL=false")
-            .withEnv("KAFKA_BOOTSTRAP_SERVERS", "kafka:19092")
-            .withExposedPorts(8080)
-            .waitingFor(Wait.forHttp("/actuator/health").forStatusCode(200))
-            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("APP_CONTAINER")));
+             .withEnv("OTEL_EXPORTER_OTLP_TRACES_ENABLED", "false")
+             .withEnv("DATABASE_URL", "jdbc:mysql://mysqldb:" + MySQLContainer.MYSQL_PORT + "/test?autoReconnect=true&useSSL=false")
+             .withEnv("KAFKA_BOOTSTRAP_SERVERS", "kafka:19092")
+             .withEnv("SPRING_RABBITMQ_HOST", "rabbitmq")
+             .withEnv("SPRING_RABBITMQ_PORT", Integer.toString(RABBITMQ_AMQP_PORT))
+             .withEnv("SPRING_RABBITMQ_USERNAME", RABBITMQ_USERNAME)
+             .withEnv("SPRING_RABBITMQ_PASSWORD", RABBITMQ_PASSWORD)
+             .withExposedPorts(8080)
+             .waitingFor(Wait.forHttp("/actuator/health").forStatusCode(200))
+             .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("APP_CONTAINER")));
    }
 
    private static void initRestAssured() {
@@ -105,9 +141,70 @@ public abstract class DefaultContainerStarter {
       Testcontainers.exposeHostPorts(MOCK_SERVER.port());
    }
 
+   protected static int getRabbitMqQueueMessageCount(final String queueName) {
+      final List<Map<String, Object>> messages = given()
+            .urlEncodingEnabled(false)
+            .baseUri("http://" + RABBITMQ_CONTAINER.getHost())
+            .port(RABBITMQ_CONTAINER.getMappedPort(RABBITMQ_MANAGEMENT_PORT))
+            .auth()
+            .preemptive()
+            .basic(RABBITMQ_USERNAME, RABBITMQ_PASSWORD)
+            .contentType("application/json")
+            .body("{\"count\":10,\"ackmode\":\"ack_requeue_true\",\"encoding\":\"auto\",\"truncate\":50000}")
+            .when()
+            .post("/api/queues/" + RABBITMQ_DEFAULT_VHOST + "/" + queueName + "/get")
+            .then()
+            .statusCode(200)
+            .extract()
+            .jsonPath()
+            .getList("$");
+
+      return messages.size();
+   }
+
+   protected static String getSingleRabbitMqQueueMessage(final String queueName) {
+      final List<Map<String, Object>> messages = given()
+            .urlEncodingEnabled(false)
+            .baseUri("http://" + RABBITMQ_CONTAINER.getHost())
+            .port(RABBITMQ_CONTAINER.getMappedPort(RABBITMQ_MANAGEMENT_PORT))
+            .auth()
+            .preemptive()
+            .basic(RABBITMQ_USERNAME, RABBITMQ_PASSWORD)
+            .contentType("application/json")
+            .body("{\"count\":1,\"ackmode\":\"ack_requeue_false\",\"encoding\":\"auto\",\"truncate\":50000}")
+            .when()
+            .post("/api/queues/" + RABBITMQ_DEFAULT_VHOST + "/" + queueName + "/get")
+            .then()
+            .statusCode(200)
+            .extract()
+            .jsonPath()
+            .getList("$");
+
+      if (messages.isEmpty()) {
+         return null;
+      }
+
+      return (String) messages.getFirst().get("payload");
+   }
+
+   private static void purgeRabbitMqQueue(final String queueName) {
+      given()
+            .urlEncodingEnabled(false)
+            .baseUri("http://" + RABBITMQ_CONTAINER.getHost())
+            .port(RABBITMQ_CONTAINER.getMappedPort(RABBITMQ_MANAGEMENT_PORT))
+            .auth()
+            .preemptive()
+            .basic(RABBITMQ_USERNAME, RABBITMQ_PASSWORD)
+            .when()
+            .delete("/api/queues/" + RABBITMQ_DEFAULT_VHOST + "/" + queueName + "/contents")
+            .then()
+            .statusCode(204);
+   }
+
    @AfterEach
    void tearDown() {
       MOCK_SERVER.resetAll();
+      purgeRabbitMqQueue(USER_COMPLETED_QUEUE);
       /* add here others resets needed after each test */
    }
 }

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -48,6 +48,11 @@
         </dependency>
         <dependency>
             <groupId>io.github.springwolf</groupId>
+            <artifactId>springwolf-amqp</artifactId>
+            <version>${springwolf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.springwolf</groupId>
             <artifactId>springwolf-ui</artifactId>
             <version>${springwolf.version}</version>
         </dependency>
@@ -84,6 +89,10 @@
         <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
 
         <!-- Observability Dependencies -->

--- a/application/src/main/java/br/com/helpdev/sample/adapters/output/rabbitmq/UserCompletedIntegrationPublisher.java
+++ b/application/src/main/java/br/com/helpdev/sample/adapters/output/rabbitmq/UserCompletedIntegrationPublisher.java
@@ -1,0 +1,57 @@
+package br.com.helpdev.sample.adapters.output.rabbitmq;
+
+import io.github.springwolf.bindings.amqp.annotations.AmqpAsyncOperationBinding;
+import io.github.springwolf.core.asyncapi.annotations.AsyncMessage;
+import io.github.springwolf.core.asyncapi.annotations.AsyncOperation;
+import io.github.springwolf.core.asyncapi.annotations.AsyncPublisher;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import br.com.helpdev.sample.core.domain.entities.User;
+import br.com.helpdev.sample.core.ports.output.UserCompletedIntegrationPublisherPort;
+
+@Service
+class UserCompletedIntegrationPublisher implements UserCompletedIntegrationPublisherPort {
+
+   private static final String USER_COMPLETED_CHANNEL = "user-completed.integration.queue";
+
+   private final RabbitTemplate rabbitTemplate;
+
+   private final String exchange;
+
+   private final String routingKey;
+
+   UserCompletedIntegrationPublisher(
+         final RabbitTemplate rabbitTemplate,
+         @Value("${integration.rabbitmq.user-completed.exchange:user-completed.integration.exchange}") final String exchange,
+         @Value("${integration.rabbitmq.user-completed.routing-key:user.completed}") final String routingKey) {
+      this.rabbitTemplate = rabbitTemplate;
+      this.exchange = exchange;
+      this.routingKey = routingKey;
+   }
+
+   @Override
+   public void sendUserCompletedPayload(final User user) {
+      publish(UserCompletedPayload.of(user));
+   }
+
+   @AsyncPublisher(
+         operation = @AsyncOperation(
+               channelName = USER_COMPLETED_CHANNEL,
+               description = "Publish completed user payloads for integration consumers",
+               message = @AsyncMessage(
+                     name = "UserCompletedPayload",
+                     contentType = "application/json",
+                     messageId = "uuid"
+               ),
+               payloadType = UserCompletedPayload.class
+         )
+   )
+   @AmqpAsyncOperationBinding
+   void publish(final UserCompletedPayload payload) {
+      rabbitTemplate.convertAndSend(exchange, routingKey, payload);
+   }
+
+}

--- a/application/src/main/java/br/com/helpdev/sample/adapters/output/rabbitmq/UserCompletedPayload.java
+++ b/application/src/main/java/br/com/helpdev/sample/adapters/output/rabbitmq/UserCompletedPayload.java
@@ -1,0 +1,45 @@
+package br.com.helpdev.sample.adapters.output.rabbitmq;
+
+import static java.util.Objects.requireNonNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import br.com.helpdev.sample.core.domain.entities.Address;
+import br.com.helpdev.sample.core.domain.entities.User;
+
+record UserCompletedPayload(
+      @Schema(title = "UUID", example = "uuid") String uuid,
+      @Schema(title = "Name", example = "John Doe") String name,
+      @Schema(title = "Email", example = "john.doe@example.com") String email,
+      @Schema(title = "Birth date", example = "2000-01-01") String birthDate,
+      @Schema(title = "Address") UserCompletedAddressPayload address) {
+
+   static UserCompletedPayload of(final User user) {
+      requireNonNull(user, "User is required");
+      return new UserCompletedPayload(
+            user.uuid().toString(),
+            user.name(),
+            user.email().value(),
+            user.birthDate().toString(),
+            UserCompletedAddressPayload.of(requireNonNull(user.address(), "Address is required for completed user payload")));
+   }
+
+}
+
+record UserCompletedAddressPayload(
+      @Schema(title = "Country", example = "Reunion") String country,
+      @Schema(title = "State", example = "Arizona") String state,
+      @Schema(title = "City", example = "East Nadia") String city,
+      @Schema(title = "Zip code", example = "39781-7908") String zipCode,
+      @Schema(title = "Street address", example = "849 Langosh Ports") String streetAddress) {
+
+   static UserCompletedAddressPayload of(final Address address) {
+      return new UserCompletedAddressPayload(
+            address.country(),
+            address.state(),
+            address.city(),
+            address.zipCode(),
+            address.streetAddress());
+   }
+
+}

--- a/application/src/main/java/br/com/helpdev/sample/adapters/output/rabbitmq/UserCompletedRabbitMqConfig.java
+++ b/application/src/main/java/br/com/helpdev/sample/adapters/output/rabbitmq/UserCompletedRabbitMqConfig.java
@@ -1,0 +1,44 @@
+package br.com.helpdev.sample.adapters.output.rabbitmq;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.ExchangeBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+class UserCompletedRabbitMqConfig {
+
+   @Bean
+   DirectExchange userCompletedExchange(
+         @Value("${integration.rabbitmq.user-completed.exchange:user-completed.integration.exchange}") final String exchangeName) {
+      return ExchangeBuilder.directExchange(exchangeName).durable(true).build();
+   }
+
+   @Bean
+   Queue userCompletedQueue(@Value("${integration.rabbitmq.user-completed.queue:user-completed.integration.queue}") final String queueName) {
+      return QueueBuilder.durable(queueName).build();
+   }
+
+   @Bean
+   Binding userCompletedBinding(
+         final Queue userCompletedQueue,
+         final DirectExchange userCompletedExchange,
+         @Value("${integration.rabbitmq.user-completed.routing-key:user.completed}") final String routingKey) {
+      return BindingBuilder.bind(userCompletedQueue).to(userCompletedExchange).with(routingKey);
+   }
+
+   @Bean
+   MessageConverter rabbitMessageConverter(final ObjectMapper objectMapper) {
+      return new Jackson2JsonMessageConverter(objectMapper);
+   }
+
+}

--- a/application/src/main/java/br/com/helpdev/sample/core/ports/output/UserCompletedIntegrationPublisherPort.java
+++ b/application/src/main/java/br/com/helpdev/sample/core/ports/output/UserCompletedIntegrationPublisherPort.java
@@ -1,0 +1,9 @@
+package br.com.helpdev.sample.core.ports.output;
+
+import br.com.helpdev.sample.core.domain.entities.User;
+
+public interface UserCompletedIntegrationPublisherPort {
+
+   void sendUserCompletedPayload(User user);
+
+}

--- a/application/src/main/java/br/com/helpdev/sample/core/usecases/UserEnricherUseCase.java
+++ b/application/src/main/java/br/com/helpdev/sample/core/usecases/UserEnricherUseCase.java
@@ -8,6 +8,7 @@ import br.com.helpdev.sample.core.domain.exceptions.UserNotFoundException;
 import br.com.helpdev.sample.core.ports.input.UserEnricherPort;
 import br.com.helpdev.sample.core.ports.output.AddressClientPort;
 import br.com.helpdev.sample.core.ports.output.AddressRepositoryPort;
+import br.com.helpdev.sample.core.ports.output.UserCompletedIntegrationPublisherPort;
 import br.com.helpdev.sample.core.ports.output.UserEventDispatcherPort;
 import br.com.helpdev.sample.core.ports.output.UserRepositoryPort;
 
@@ -18,14 +19,18 @@ class UserEnricherUseCase implements UserEnricherPort {
 
    private final UserEventDispatcherPort userEventDispatcherPort;
 
+   private final UserCompletedIntegrationPublisherPort userCompletedIntegrationPublisherPort;
+
    private final AddressClientPort addressClientPort;
 
    private final AddressRepositoryPort addressRepositoryPort;
 
    UserEnricherUseCase(final UserRepositoryPort userRepositoryPort, final UserEventDispatcherPort userEventDispatcherPort,
+         final UserCompletedIntegrationPublisherPort userCompletedIntegrationPublisherPort,
          final AddressClientPort addressClientPort, final AddressRepositoryPort addressRepositoryPort) {
       this.userRepositoryPort = userRepositoryPort;
       this.userEventDispatcherPort = userEventDispatcherPort;
+      this.userCompletedIntegrationPublisherPort = userCompletedIntegrationPublisherPort;
       this.addressClientPort = addressClientPort;
       this.addressRepositoryPort = addressRepositoryPort;
    }
@@ -37,6 +42,7 @@ class UserEnricherUseCase implements UserEnricherPort {
       final var savedAddress = addressRepositoryPort.save(user, address);
       final var userWithAddress = user.withAddress(savedAddress);
       userEventDispatcherPort.sendUserAddressUpdatedEvent(userWithAddress);
+      userCompletedIntegrationPublisherPort.sendUserCompletedPayload(userWithAddress);
    }
 
 }

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -14,6 +14,8 @@ springwolf.docket.info.title=${spring.application.name}
 springwolf.docket.info.version=1.0.0
 springwolf.docket.servers.kafka.protocol=kafka
 springwolf.docket.servers.kafka.host=${spring.kafka.bootstrap-servers}
+springwolf.docket.servers.rabbitmq.protocol=amqp
+springwolf.docket.servers.rabbitmq.host=${spring.rabbitmq.host}:${spring.rabbitmq.port}
 
 # Database
 spring.datasource.url=${DATABASE_URL:jdbc:mysql://localhost:3306/sampledb}
@@ -45,6 +47,15 @@ spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.S
 # Kafka Producer
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
+# RabbitMQ
+spring.rabbitmq.host=${SPRING_RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:user}
+spring.rabbitmq.password=${SPRING_RABBITMQ_PASSWORD:password}
+# RabbitMQ Integration Payload
+integration.rabbitmq.user-completed.exchange=${USER_COMPLETED_RABBITMQ_EXCHANGE:user-completed.integration.exchange}
+integration.rabbitmq.user-completed.routing-key=${USER_COMPLETED_RABBITMQ_ROUTING_KEY:user.completed}
+integration.rabbitmq.user-completed.queue=${USER_COMPLETED_RABBITMQ_QUEUE:user-completed.integration.queue}
 #Clients
 spring.cloud.openfeign.client.config.random-data-api.url=${RANDOM_DATA_API_URL:https://random-data-api.com}
 # Logging

--- a/application/src/test/java/br/com/helpdev/sample/adapters/output/rabbitmq/UserCompletedIntegrationPublisherTest.java
+++ b/application/src/test/java/br/com/helpdev/sample/adapters/output/rabbitmq/UserCompletedIntegrationPublisherTest.java
@@ -1,0 +1,50 @@
+package br.com.helpdev.sample.adapters.output.rabbitmq;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import br.com.helpdev.sample.core.domain.entities.Address;
+import br.com.helpdev.sample.core.domain.entities.User;
+import br.com.helpdev.sample.core.domain.vo.Email;
+
+@ExtendWith(MockitoExtension.class)
+class UserCompletedIntegrationPublisherTest {
+
+   private static final String EXCHANGE = "user-completed.integration.exchange";
+
+   private static final String ROUTING_KEY = "user.completed";
+
+   @Mock
+   private RabbitTemplate rabbitTemplate;
+
+   private UserCompletedIntegrationPublisher userCompletedIntegrationPublisher;
+
+   private User user;
+
+   @BeforeEach
+   void setUp() {
+      userCompletedIntegrationPublisher = new UserCompletedIntegrationPublisher(rabbitTemplate, EXCHANGE, ROUTING_KEY);
+      final var userUuid = UUID.randomUUID();
+      final var address = new Address(1L, "Reunion", "Arizona", "East Nadia", "39781-7908", "849 Langosh Ports");
+      user = new User(1L, userUuid, "John Doe", Email.of("john.doe@example.com"), LocalDate.of(2000, 1, 1), address);
+   }
+
+   @Test
+   void sendUserCompletedPayload_shouldPublishCompletedUserPayload() {
+      userCompletedIntegrationPublisher.sendUserCompletedPayload(user);
+
+      verify(rabbitTemplate).convertAndSend(EXCHANGE, ROUTING_KEY, UserCompletedPayload.of(user));
+      verifyNoMoreInteractions(rabbitTemplate);
+   }
+
+}

--- a/application/src/test/java/br/com/helpdev/sample/core/usecases/UserEnricherUseCaseTest.java
+++ b/application/src/test/java/br/com/helpdev/sample/core/usecases/UserEnricherUseCaseTest.java
@@ -4,9 +4,10 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.mockito.Mockito.inOrder;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +22,7 @@ import br.com.helpdev.sample.core.domain.entities.User;
 import br.com.helpdev.sample.core.domain.exceptions.UserNotFoundException;
 import br.com.helpdev.sample.core.domain.vo.Email;
 import br.com.helpdev.sample.core.ports.output.AddressClientPort;
+import br.com.helpdev.sample.core.ports.output.UserCompletedIntegrationPublisherPort;
 import br.com.helpdev.sample.core.ports.output.AddressRepositoryPort;
 import br.com.helpdev.sample.core.ports.output.UserEventDispatcherPort;
 import br.com.helpdev.sample.core.ports.output.UserRepositoryPort;
@@ -33,6 +35,9 @@ class UserEnricherUseCaseTest {
 
    @Mock
    private UserEventDispatcherPort userEventDispatcherPort;
+
+   @Mock
+   private UserCompletedIntegrationPublisherPort userCompletedIntegrationPublisherPort;
 
    @Mock
    private AddressClientPort addressClientPort;
@@ -61,6 +66,8 @@ class UserEnricherUseCaseTest {
       when(userRepositoryPort.findByUuid(userUuid)).thenReturn(Optional.empty());
 
       assertThrows(UserNotFoundException.class, () -> userEnricherUseCase.enrichUser(userUuid));
+
+      verifyNoInteractions(addressClientPort, addressRepositoryPort, userEventDispatcherPort, userCompletedIntegrationPublisherPort);
    }
 
    @Test
@@ -71,9 +78,12 @@ class UserEnricherUseCaseTest {
 
       userEnricherUseCase.enrichUser(userUuid);
 
+      final var userWithAddress = user.withAddress(address);
       verify(userRepositoryPort).findByUuid(userUuid);
       verify(addressClientPort).findUserAddress(user);
       verify(addressRepositoryPort).save(user, address);
-      verify(userEventDispatcherPort).sendUserAddressUpdatedEvent(any(User.class));
+      final var inOrder = inOrder(userEventDispatcherPort, userCompletedIntegrationPublisherPort);
+      inOrder.verify(userEventDispatcherPort).sendUserAddressUpdatedEvent(userWithAddress);
+      inOrder.verify(userCompletedIntegrationPublisherPort).sendUserCompletedPayload(userWithAddress);
    }
 }

--- a/docs/adr/0004-use-rabbitmq-for-integration-payload-delivery.md
+++ b/docs/adr/0004-use-rabbitmq-for-integration-payload-delivery.md
@@ -1,0 +1,38 @@
+# 4. Use RabbitMQ for Integration Payload Delivery
+
+## Context
+The service already uses Kafka for internal event streaming, as recorded in ADR `0003-use-kafka-for-event-streaming.md`.
+
+We now need a second asynchronous integration path for a specific downstream system that expects a completed user payload after `enrichUser(...)` succeeds. This requirement is not about replacing Kafka or introducing a second event-streaming platform. It is about delivering a targeted payload to a dedicated integration channel.
+
+## Decision
+We will keep Kafka as the platform for event streaming and introduce RabbitMQ as a separate outbound channel for integration payload delivery.
+
+The RabbitMQ publication will happen only after a successful `enrichUser(...)` execution and after the existing Kafka `sendUserAddressUpdatedEvent(...)` call returns.
+
+## Consequences
+- Kafka remains the source for event-streaming workflows in this service.
+- RabbitMQ is added only for targeted microservice communication where the consumer expects a completed user payload.
+- The application now depends on two asynchronous transports, which increases configuration, testing, and operational complexity.
+- Local and acceptance-test infrastructure must include RabbitMQ support.
+
+## Alternatives Considered
+- Keep Kafka as the only asynchronous transport and force the integration consumer to consume streaming events.
+- Replace Kafka with RabbitMQ for all asynchronous communication.
+- Expose the completed user data through synchronous REST-only integration.
+
+## Rationale
+The downstream integration requirement is payload-oriented and broker-specific, while the existing Kafka flow is still the correct choice for event streaming.
+
+Using RabbitMQ only for this dedicated integration preserves ADR `0003` instead of diluting it. It also keeps the implementation explicit: Kafka continues to describe domain event flow, while RabbitMQ handles a direct integration contract.
+
+## Date
+2026-04-12
+
+## Status
+Accepted
+
+## Links
+- [ADR 0003 - Use Kafka for Event Streaming](0003-use-kafka-for-event-streaming.md)
+- [Kafka](https://kafka.apache.org/)
+- [RabbitMQ](https://www.rabbitmq.com/)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,6 +42,7 @@ Follow these steps when creating a new ADR:
 | 0001 | [Adopt REST for API Communication](0001-adopt-rest-for-api-communication.md) | Accepted  | 2024-12-31 |
 | 0002 | [Use MySQL as the Primary Database](0002-use-mysql.md)                       | Accepted  | 2024-12-31 |
 | 0003 | [Use Kafka for Event Streaming](0003-use-kafka-for-event-streaming.md)       | Accepted  | 2024-12-31 |
+| 0004 | [Use RabbitMQ for Integration Payload Delivery](0004-use-rabbitmq-for-integration-payload-delivery.md) | Accepted  | 2026-04-12 |
 
 ---
 

--- a/docs/adr/README.pt.md
+++ b/docs/adr/README.pt.md
@@ -40,6 +40,7 @@ Siga estes passos ao criar um novo ADR:
 | 0001 | [Adotar REST para Comunicação de API](0001-adopt-rest-for-api-communication.md) | Aceito    | 2024-12-31 |
 | 0002 | [Usar MySQL como Banco de Dados Primário](0002-use-mysql.md)                      | Aceito    | 2024-12-31 |
 | 0003 | [Usar Kafka para Streaming de Eventos](0003-use-kafka-for-event-streaming.md)  | Aceito    | 2024-12-31 |
+| 0004 | [Usar RabbitMQ para Entrega de Payloads de Integração](0004-use-rabbitmq-for-integration-payload-delivery.md) | Aceito    | 2026-04-12 |
 
 ---
 
@@ -53,4 +54,3 @@ Consulte o arquivo [Modelo de ADR](template.md) para criar novos ADRs.
 
 - [O que é um ADR?](https://adr.github.io/)
 - [Modelos e Exemplos de ADR](https://github.com/joelparkerhenderson/architecture_decision_record)
-


### PR DESCRIPTION
## Summary
- publish a dedicated RabbitMQ user-completed payload after successful enrichment and after the Kafka updated-event dispatch returns
- add a separate RabbitMQ output port, adapter, topology, and runtime configuration
- document the architectural split with ADR 0004 and cover the flow in unit and acceptance tests

## Context
- Refs #6
- Stacked on top of #7 so the Dockerfile fix can merge independently first

## Validation
- `make run-all-tests`