### PR TITLE
Add TDD loop skill

### DIFF
--- a/.agents/skills/hexagon-scaffold/SKILL.md
+++ b/.agents/skills/hexagon-scaffold/SKILL.md
@@ -34,13 +34,14 @@ Use when you need to add a new business capability that should follow the reposi
 
 ## Workflow
 
-1. Start in the core: define domain records or value objects and the smallest input or output port set that expresses the use case.
-2. Implement package-private use cases that implement input ports and depend only on output ports and domain types.
-3. Add inbound adapters that translate transport concerns into the input-port API.
-4. Add outbound adapters that implement output ports and keep framework details out of the core.
-5. Add mapper, DTO, and entity layers only where boundaries require them.
-6. Mirror existing patterns before inventing new ones: `UserCreatorUseCase`, `UserController`, `UserRepository`, `AddressClient`, and `UserEventDispatcher`.
-7. Add focused unit tests and let `archunit-guard` verify the structure.
+1. Start with `tdd-loop`: pick the smallest failing test that describes the next behavior increment, preferably in the core.
+2. Define domain records or value objects and the smallest input or output port set that expresses the use case.
+3. Implement package-private use cases that implement input ports and depend only on output ports and domain types.
+4. Add inbound adapters that translate transport concerns into the input-port API.
+5. Add outbound adapters that implement output ports and keep framework details out of the core.
+6. Add mapper, DTO, and entity layers only where boundaries require them.
+7. Mirror existing patterns before inventing new ones: `UserCreatorUseCase`, `UserController`, `UserRepository`, `AddressClient`, and `UserEventDispatcher`.
+8. Keep the red-green-refactor cycle tight: make the smallest production change for the current failing test, then let `archunit-guard` verify the structure.
 
 ## Output Shape
 
@@ -48,7 +49,7 @@ Use when you need to add a new business capability that should follow the reposi
 2. Input and output ports with the `Port` suffix
 3. Package-private use case implementations with the `UseCase` suffix
 4. Adapter implementations, DTOs or entities, and mappers only where needed
-5. Unit test coverage for core logic and adapter boundaries
+5. Unit test coverage for core logic and adapter boundaries, written first through the TDD loop
 
 ## Rules
 

--- a/.agents/skills/tdd-loop/SKILL.md
+++ b/.agents/skills/tdd-loop/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: tdd-loop
+description: Use when implementing new behavior or fixing behavior through a test-first red-green-refactor loop.
+---
+
+# TDD Loop
+
+Use before changing production code when the task adds or changes observable behavior.
+
+## Destination
+
+- matching tests under `application/src/test/java/...`
+- matching production code under `application/src/main/java/...`
+- `acceptance-test/src/test/java/...` when behavior must be proven across runtime boundaries
+
+## Use For
+
+- new domain rules, use cases, or adapters
+- bug fixes with a reproducible failing behavior
+- refactors that need characterization coverage before code movement
+- controller, repository, or integration changes that should be driven by tests first
+
+## Inputs
+
+1. The smallest observable behavior to add or change
+2. The narrowest level that can expose it: domain, use case, adapter, or acceptance
+3. The expected success result and any critical failure path
+4. Existing classes, ports, or adapters that the change should extend
+
+## Workflow
+
+1. Choose the smallest useful test seam first. Prefer domain or use case tests before controller, repository, or acceptance coverage.
+2. Write one failing test that captures the next behavior increment. Reuse the repository's JUnit 5 and Mockito style from `UserCreatorUseCaseTest`, `UserControllerTest`, and `UserRepositoryTest`.
+3. Run the narrowest target that proves the test is red.
+4. Implement the smallest production change that makes that one test pass.
+5. Run the focused test again, then widen to `make run-unit-tests` when the slice is coherent.
+6. Refactor only with the suite green, keeping naming, package boundaries, and port directions aligned with the hexagonal rules.
+7. When the behavior crosses HTTP, messaging, containers, or external integrations, add or extend acceptance coverage with `acceptance-scenario-scaffold` after the unit-level loop is stable.
+8. When the change introduces a new feature slice, combine this skill with `hexagon-scaffold`; if ArchUnit fails, use `archunit-guard` to fix structure instead of weakening rules.
+
+## Output Shape
+
+1. A failing test added before the production change
+2. The smallest production change needed to satisfy the new behavior
+3. Refactored code with the tests still green
+4. Broader regression coverage only when the behavior boundary justifies it
+
+## Rules
+
+- Do not start production code for new behavior without first expressing the next increment as a test.
+- Keep the loop small: one behavior increment, one failing test, one passing change.
+- Prefer unit tests as the default TDD seam; use acceptance tests only when user-visible behavior spans module or infrastructure boundaries.
+- Match existing naming and tooling: JUnit 5, Mockito, and the repository's `make run-unit-tests` and `make run-acceptance-tests` targets.
+- If the task is documentation-only, pure wiring with no behavior change, or an unavoidable external contract spike, say why TDD is being limited instead of silently skipping it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,9 @@ Then route to the relevant artifact skill:
 
 ## Implementation Skills
 
-Use these repository-native skills for common delivery workflows:
+Use these repository-native skills for common delivery workflows. For new production behavior, start with `.agents/skills/tdd-loop/SKILL.md` and then layer on the more specialized skills below as needed.
 
+- `.agents/skills/tdd-loop/SKILL.md` for driving new code implementation through a red-green-refactor loop
 - `.agents/skills/hexagon-scaffold/SKILL.md` for adding a new feature slice across core, ports, adapters, and tests
 - `.agents/skills/archunit-guard/SKILL.md` for diagnosing or preserving architecture rules enforced by ArchUnit
 - `.agents/skills/acceptance-scenario-scaffold/SKILL.md` for black-box acceptance coverage in the `acceptance-test/` module


### PR DESCRIPTION
## Summary
- add a repo-native `tdd-loop` skill for test-driven implementation work
- wire the new skill into `AGENTS.md` so it is the starting point for new production behavior
- update `hexagon-scaffold` to begin feature work from a failing test and keep the red-green-refactor loop explicit