### PR TITLE
Mention docs article in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ The flow works like this:
 
 This keeps documentation lean, decision-oriented, and connected to execution instead of turning every discussion into a permanent artifact.
 
+Read more about this perspective in [Documentacao na era da IA: quando a documentacao vira contexto de execucao](https://medium.com/@guilherme.zarelli/documenta%C3%A7%C3%A3o-na-era-da-ia-quando-a-documenta%C3%A7%C3%A3o-vira-contexto-de-execu%C3%A7%C3%A3o-cb8d6fdf84ed) _(Portuguese)_.
+
 
 ## **Contribute**
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -228,6 +228,8 @@ O fluxo funciona assim:
 
 Com isso, a documentação fica enxuta, orientada a decisão e conectada à execução, em vez de transformar toda conversa em artefato permanente.
 
+Leia mais em [Documentação na era da IA: quando a documentação vira contexto de execução](https://medium.com/@guilherme.zarelli/documenta%C3%A7%C3%A3o-na-era-da-ia-quando-a-documenta%C3%A7%C3%A3o-vira-contexto-de-execu%C3%A7%C3%A3o-cb8d6fdf84ed).
+
 
 ## **Contribua**
 


### PR DESCRIPTION
## Summary
- mention the article about documentation as execution context in the Docs section
- add the reference in both README variants

## Testing
- not run (documentation-only changes)